### PR TITLE
Acquire Multicast lock to receive multicast messages over wifi.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@ Redistribution and use in source and binary forms, with or without modification,
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
     
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/apps4av/avarehelper/MainActivity.java
+++ b/app/src/main/java/com/apps4av/avarehelper/MainActivity.java
@@ -42,6 +42,7 @@ public class MainActivity extends ActionBarActivity implements
 
     private Fragment[] mFragments = new Fragment[9];
 
+    private WifiManager.MulticastLock multicastLock
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -97,6 +98,11 @@ public class MainActivity extends ActionBarActivity implements
                 getString(R.string.Help)
                 }), this);
 
+
+        // Acquire Multicast Lock to receive multicast packets over Wifi.
+        WifiManager wm = (WifiManager)getSystemService(Context.WIFI_SERVICE);
+        multicastLock = wm.createMulticastLock("avarehelper");
+        multicastLock.acquire();
     }
     
     @Override
@@ -106,6 +112,9 @@ public class MainActivity extends ActionBarActivity implements
          * Clean up stuff on exit
          */
         getApplicationContext().unbindService(mConnection);        
+
+        // Release multicast lock.
+        multicastLock.release();
     }
    
     /**


### PR DESCRIPTION
http://developer.android.com/reference/android/net/wifi/WifiManager.MulticastLock.html


"Normally the Wifi stack filters out packets not explicitly addressed to this device. Acquring a MulticastLock will cause the stack to receive packets addressed to multicast addresses."