### PR TITLE
Don't cast double -> int -> double.

### DIFF
--- a/app/src/main/java/com/apps4av/avarehelper/connections/BufferProcessor.java
+++ b/app/src/main/java/com/apps4av/avarehelper/connections/BufferProcessor.java
@@ -215,7 +215,7 @@ public class BufferProcessor {
                         // invalid
                         continue;
                     }
-                    object.put("altitude", (double) altitude);
+                    object.put("altitude", (double)((OwnshipGeometricAltitudeMessage)m).mAltitudeWGS84);
                     object.put("time", (long) m.getTime());
                 } catch (JSONException e1) {
                     continue;

--- a/app/src/main/java/com/apps4av/avarehelper/gdl90/OwnshipMessage.java
+++ b/app/src/main/java/com/apps4av/avarehelper/gdl90/OwnshipMessage.java
@@ -33,7 +33,7 @@ public class OwnshipMessage extends Message {
     public int mHorizontalVelocity;
     public int mVerticalVelocity;
     
-    public int mAltitude;
+    public double mAltitude;
     
     boolean mIsTrackHeadingValid;
     boolean mIsTrackHeadingTrueTrackAngle;
@@ -78,7 +78,7 @@ public class OwnshipMessage extends Message {
             /*
              * In meters
              */
-            mAltitude = (int)((double)alt / 3.28084);
+            mAltitude = (double)alt / 3.28084;
         }
 
         /*


### PR DESCRIPTION
GDL90 altitudes are converted from feet to meters in the helper, casted to an `int`. This is then sent to Avare which parses it as a `double`, then converts it back into feet. Avare then casts it back into an int for the interface. I assume that there are other services using `IHelperService` which is expecting that Avare receive altitude in meter units.

Instead of just using the same (int value) of feet that is sent via GDL90, this fix reduces the number of type casts to try to preserve precision in the altitude.