### PR TITLE
Persist chosen fragment and WiFi port on restart

### DIFF
--- a/app/src/main/java/com/apps4av/avarehelper/MainActivity.java
+++ b/app/src/main/java/com/apps4av/avarehelper/MainActivity.java
@@ -31,6 +31,7 @@ import android.widget.ArrayAdapter;
 import android.widget.TextView;
 
 import com.apps4av.avarehelper.connections.ConnectionFactory;
+import com.apps4av.avarehelper.storage.Preferences;
 import com.apps4av.avarehelper.utils.GenericCallback;
 import com.apps4av.avarehelper.utils.Logger;
 
@@ -39,7 +40,9 @@ import java.util.HashMap;
 
 public class MainActivity extends ActionBarActivity implements
     ActionBar.OnNavigationListener {
-    
+
+    private final int mPrefFragment = 1;
+
     private TextView mTextLog;
     private TextView mTextStatus;
     
@@ -147,6 +150,16 @@ public class MainActivity extends ActionBarActivity implements
             //newly created, compute data
             mState = new HashMap<String, String>();
             mState.put("fragmentIndex", "0");
+            // attempt to load last selected fragment
+            try {
+                Preferences p=new Preferences(this);
+                int id = Integer.valueOf(p.getEditTextValue(mPrefFragment));
+                if(id >= 0) {
+                    actionBar.setSelectedNavigationItem(id);
+                }
+            }
+            catch (Exception e) {
+            }
         }
     }
 
@@ -216,6 +229,10 @@ public class MainActivity extends ActionBarActivity implements
 
         // Store fragment we are showing now
         mState.put("fragmentIndex", Integer.toString(itemPosition));
+
+        // save current fragment
+        Preferences p = new Preferences(this);
+        p.setEditTextValue(mPrefFragment,Integer.toString(itemPosition));
 
         switch(itemPosition) {
         

--- a/app/src/main/java/com/apps4av/avarehelper/WiFiInFragment.java
+++ b/app/src/main/java/com/apps4av/avarehelper/WiFiInFragment.java
@@ -111,7 +111,14 @@ public class WiFiInFragment extends Fragment {
             mConnectFileSaveButton.setText(mContext.getString(R.string.Save));
         }
 
-        mTextWifiPort.setText(mWifi.getParam());
+        // if port text not blank, set the connections port
+        if(mTextWifiPort.length()>0) {
+            mWifi.setParam(mTextWifiPort.toString());
+        }
+        else {
+            // nothing set, use default
+            mTextWifiPort.setText(mWifi.getParam());
+        }
 
     }
 

--- a/app/src/main/java/com/apps4av/avarehelper/connections/Connection.java
+++ b/app/src/main/java/com/apps4av/avarehelper/connections/Connection.java
@@ -238,4 +238,8 @@ public abstract class Connection {
     public abstract void disconnect();
     public abstract boolean connect(String param, boolean securely);
     public abstract String getParam();
+
+    // TODO should be abstract
+    public void setParam(String param) {}
+
 }

--- a/app/src/main/java/com/apps4av/avarehelper/connections/WifiConnection.java
+++ b/app/src/main/java/com/apps4av/avarehelper/connections/WifiConnection.java
@@ -150,6 +150,14 @@ public class WifiConnection extends Connection {
         return Integer.toString(mPort);
     }
 
+    public void setParam(String param) {
+        try {
+            mPort=Integer.valueOf(param);
+        }
+        catch(Exception e) {
+        }
+    }
+
     /**
      * 
      */


### PR DESCRIPTION
Got sick of constantly having to select WiFi and update the port when connecting to Stratux, these changes save the currently selected fragment and WiFi port to the shared preferences.