### PR TITLE
Fixed 'unknown' METAR condition which appeared white

### DIFF
--- a/app/src/main/java/com/apps4av/avarehelper/utils/MetarFlightCategory.java
+++ b/app/src/main/java/com/apps4av/avarehelper/utils/MetarFlightCategory.java
@@ -60,7 +60,8 @@ public class MetarFlightCategory {
         if((isCeiling && ceilingFt < 3000 && ceilingFt >= 1000) || (visibility >= 3 && visibility <= 5)) {
             return "MVFR";
         }
-        if((ceilingFt > 3000 || (!isCeiling)) && (visibility > 5)) {
+        // Ceilings of 3000 were causing 'unknown' to occur
+        if((ceilingFt >= 3000 || (!isCeiling)) && (visibility > 5)) {
             return "VFR";
         }
         return "Unknown";


### PR DESCRIPTION
This fixes the 'White' METARs in Avare. Problem was some stations had a ceiling of 3000 feet which was not handled