### PR TITLE
X-Plane 11 buffer read fix

### DIFF
--- a/app/src/main/java/com/apps4av/avarehelper/connections/XplaneConnection.java
+++ b/app/src/main/java/com/apps4av/avarehelper/connections/XplaneConnection.java
@@ -82,7 +82,7 @@ public class XplaneConnection extends Connection {
                         continue;
                     }
 
-                    String input = new String(buffer);
+                    String input = new String(buffer, 0, red);
                     if(input.startsWith("XGPS")) {
                         String tokens[] = input.split(",");
                         if(tokens.length >= 6) {


### PR DESCRIPTION
The input string for updating the GPS location from X-Plane 11 was pulling extra garbage from the buffer left over from longer messages. This would sometimes lead to numbers with extra decimal places (1.000.66) that could not be parsed and this state would continue until the buffer happened to be a valid number. 