### PR TITLE
Add Dump1090 JSON feeds support.

### DIFF
--- a/app/src/main/java/com/apps4av/avarehelper/BackgroundService.java
+++ b/app/src/main/java/com/apps4av/avarehelper/BackgroundService.java
@@ -45,6 +45,7 @@ public class BackgroundService extends Service {
     private Connection mWifiCon;
     private Connection mXplaneCon;
     private Connection mMsfsCon;
+    private Connection mDump1090Con;
     private Timer mTimer;
     private GenericCallback mCb;
 
@@ -73,6 +74,7 @@ public class BackgroundService extends Service {
             mWifiCon.setHelper(IHelper.Stub.asInterface(service));
             mXplaneCon.setHelper(IHelper.Stub.asInterface(service));
             mMsfsCon.setHelper(IHelper.Stub.asInterface(service));
+            mDump1090Con.setHelper(IHelper.Stub.asInterface(service));
         }
 
         /* (non-Javadoc)
@@ -128,6 +130,7 @@ public class BackgroundService extends Service {
         mWifiCon = ConnectionFactory.getConnection("WifiConnection", this);
         mXplaneCon = ConnectionFactory.getConnection("XplaneConnection", this);
         mMsfsCon = ConnectionFactory.getConnection("MsfsConnection", this);
+        mDump1090Con = ConnectionFactory.getConnection("Dump1090Connection", this);
         mHelperService = null;
         
         mTimer = new Timer();
@@ -156,6 +159,7 @@ public class BackgroundService extends Service {
 	        mWifiCon.stop();
 	        mXplaneCon.stop();
 	        mMsfsCon.stop();
+	        mDump1090Con.stop();
         }
         catch(Exception e) {
         	

--- a/app/src/main/java/com/apps4av/avarehelper/Dump1090Fragment.java
+++ b/app/src/main/java/com/apps4av/avarehelper/Dump1090Fragment.java
@@ -27,11 +27,6 @@ import com.apps4av.avarehelper.connections.ConnectionFactory;
 import com.apps4av.avarehelper.storage.Preferences;
 import com.apps4av.avarehelper.storage.SavedEditText;
 
-/**
- * 
- * @author zkhan
- *
- */
 public class Dump1090Fragment extends Fragment {
     
     private Connection mDump1090;

--- a/app/src/main/java/com/apps4av/avarehelper/Dump1090Fragment.java
+++ b/app/src/main/java/com/apps4av/avarehelper/Dump1090Fragment.java
@@ -1,0 +1,86 @@
+/*
+Copyright (c) 2012, Apps4Av Inc. (apps4av.com) 
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+    *     * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+    *
+    *     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+package com.apps4av.avarehelper;
+
+
+import android.content.Context;
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.View.OnClickListener;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.CheckBox;
+
+import com.apps4av.avarehelper.connections.Connection;
+import com.apps4av.avarehelper.connections.ConnectionFactory;
+import com.apps4av.avarehelper.storage.Preferences;
+import com.apps4av.avarehelper.storage.SavedEditText;
+
+/**
+ * 
+ * @author zkhan
+ *
+ */
+public class Dump1090Fragment extends Fragment {
+    
+    private Connection mDump1090;
+    private CheckBox mConState;
+    private Context mContext;
+    private SavedEditText mIpAddress;
+
+    @Override  
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {  
+        
+        mContext = container.getContext();
+
+        View view = inflater.inflate(R.layout.layout_dump1090, container, false);
+
+        /*
+         * Dump1090 connection
+         */
+        mIpAddress = (SavedEditText)view.findViewById(R.id.main_ip_address);
+        mConState = (CheckBox)view.findViewById(R.id.main_connect1090);
+        mConState.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (((CheckBox) v).isChecked()) {
+                    mDump1090.connect(mIpAddress.getText().toString(), false);
+                    mDump1090.start(new Preferences(getActivity()));
+                } else {
+                    mDump1090.stop();
+                    mDump1090.disconnect();
+                }
+            }
+        });
+
+        /*
+         * Get Connection
+         */
+        mDump1090 = ConnectionFactory.getConnection("Dump1090Connection", mContext);
+
+        setStates();
+        return view;  
+        
+    }
+    
+    /**
+     * 
+     */
+    private void setStates() { mConState.setChecked(mDump1090.isConnected()); }
+
+    @Override  
+    public void onDestroyView() {  
+        super.onDestroyView();
+    }    
+} 

--- a/app/src/main/java/com/apps4av/avarehelper/MainActivity.java
+++ b/app/src/main/java/com/apps4av/avarehelper/MainActivity.java
@@ -45,7 +45,7 @@ public class MainActivity extends ActionBarActivity implements
 
     private Preferences mPref;
 
-    private Fragment[] mFragments = new Fragment[10];
+    private Fragment[] mFragments = new Fragment[11];
 
     private WifiManager.MulticastLock mMulticastLock;
 
@@ -91,6 +91,7 @@ public class MainActivity extends ActionBarActivity implements
         mFragments[pos++] = new USBInFragment();
         mFragments[pos++] = new HelpFragment();
         mFragments[pos++] = new PreferencesFragment();
+        mFragments[pos++] = new Dump1090Fragment();
 
         for(int i = 0; i < pos; i++) {
             mFragments[i].setArguments(args);
@@ -111,7 +112,8 @@ public class MainActivity extends ActionBarActivity implements
                 getString(R.string.GPSSIM), 
                 getString(R.string.USBIN),
                 getString(R.string.Help),
-                getString(R.string.Preferences)
+                getString(R.string.Preferences),
+                "Dump1090"
                 }), this);
 
 
@@ -241,6 +243,9 @@ public class MainActivity extends ActionBarActivity implements
                 PreferencesFragment pref = (PreferencesFragment) mFragments[itemPosition];
                 fragmentTransaction.replace(R.id.detailFragment, pref);
                 break;
+            case 10:
+                Dump1090Fragment d1090 = (Dump1090Fragment) mFragments[itemPosition];
+                fragmentTransaction.replace(R.id.detailFragment, d1090);
         }
 
         fragmentTransaction.commit();

--- a/app/src/main/java/com/apps4av/avarehelper/connections/ConnectionFactory.java
+++ b/app/src/main/java/com/apps4av/avarehelper/connections/ConnectionFactory.java
@@ -46,6 +46,9 @@ public class ConnectionFactory {
         if(type.equals("XplaneConnection")) {
             return XplaneConnection.getInstance(ctx);
         }
+        if(type.equals("Dump1090Connection")) {
+            return Dump1090Connection.getInstance(ctx);
+        }
         return null;
     }
 
@@ -63,6 +66,7 @@ public class ConnectionFactory {
         s += getConnection("FileConnectionIn", ctx).isConnected() ? "," + ctx.getString(R.string.Play) : "";
         s += getConnection("GPSSimulatorConnection", ctx).isConnected() ? "," + ctx.getString(R.string.GPSSIM) : "";
         s += getConnection("USBConnectionIn", ctx).isConnected() ? "," + ctx.getString(R.string.USBIN) : "";
+        s += getConnection("Dump1090Connection", ctx).isConnected() ? "," + ctx.getString(R.string.DUMP1090) : "";
         if(s.startsWith(",")) {
             s = s.substring(1);
         }

--- a/app/src/main/java/com/apps4av/avarehelper/connections/Dump1090Connection.java
+++ b/app/src/main/java/com/apps4av/avarehelper/connections/Dump1090Connection.java
@@ -1,0 +1,148 @@
+package com.apps4av.avarehelper.connections;
+
+import android.content.Context;
+
+import com.apps4av.avarehelper.utils.GenericCallback;
+import com.apps4av.avarehelper.utils.Logger;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+
+
+public class Dump1090Connection extends Connection {
+
+    private static Dump1090Connection mConnection;
+    private URL mURL;
+
+    private Dump1090Connection() {
+        super("Dump1090 Input");
+        setCallback(new GenericCallback() {
+            @Override
+            public Object callback(Object o, Object o1) {
+                while(isRunning()) {
+                    JSONArray trafficList = fetchDump1090JSON();
+
+                    if (null != trafficList) {
+                        for (int i = 0; i < trafficList.length(); i++) {
+                            JSONObject sent = new JSONObject();
+                            try {
+                                JSONObject recv = trafficList.getJSONObject(i);
+                                sent.put("type", "traffic");
+                                sent.put("longitude", recv.getDouble("lon"));
+                                sent.put("latitude", recv.getDouble("lat"));
+                                sent.put("speed", recv.getDouble("speed"));
+                                sent.put("bearing", recv.getDouble("track"));
+                                sent.put("altitude", recv.getDouble("altitude"));
+                                sent.put("callsign", recv.getString("flight").trim());
+                                sent.put("address", Integer.decode("0x" + recv.getString("hex")));
+                                sent.put("time", System.currentTimeMillis());
+                            } catch (JSONException e1) {
+                                Logger.Logit(e1.toString());
+                                continue;
+                            }
+                            sendDataToHelper(sent.toString());
+                        }
+                    }
+
+                    try {
+                        Thread.sleep(1000);
+                    } catch(Exception e) {
+                    }
+                }
+                return null;
+            }
+        });
+    }
+
+    @Override
+    public boolean connect(String to, boolean secure) {
+        try {
+            Logger.Logit("Fetch Dump1090 feed from http://" + to + "/data.json");
+            mURL = new URL("http://" + to + "/data.json");
+            connectConnection();
+        } catch (Exception e) {
+            Logger.Logit("Illegal URL format.");
+            mURL = null;
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void disconnect() {
+        mURL = null;
+        disconnectConnection();
+    }
+
+    public static Dump1090Connection getInstance(Context ctx) {
+        if(null == mConnection) {
+            mConnection = new Dump1090Connection();
+        }
+        return mConnection;
+    }
+
+    @Override
+    public List<String> getDevices() {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public String getConnDevice() {
+        return "";
+    }
+
+    public JSONArray fetchDump1090JSON() {
+        if (null == mURL) return null;
+
+        StringBuffer response = new StringBuffer();
+        HttpURLConnection conn = null;
+        try {
+            conn = (HttpURLConnection) mURL.openConnection();
+            conn.setDoOutput(false);
+            conn.setDoInput(true);
+            conn.setUseCaches(false);
+            conn.setRequestMethod("GET");
+            conn.setRequestProperty("Content-Type", "application/json;charset=utf-8");
+
+            int status = conn.getResponseCode();
+            if (status != 200) {
+                // Return empty if fetch failed.
+                Logger.Logit("HTTP connection failed, status code: " + status);
+                return null;
+            } else {
+                BufferedReader in = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+                String inputLine;
+                while ((inputLine = in.readLine()) != null) {
+                    response.append(inputLine);
+                }
+                in.close();
+            }
+        } catch (Exception e) {
+            return null;
+        } finally {
+            if (conn != null) {
+                conn.disconnect();
+            }
+            if (response.length() > 0) {
+                try {
+                    JSONArray array = new JSONArray(response.toString());
+                    Logger.Logit("Get traffic JSON array of size " + array.length());
+                    return array;
+                } catch (Exception e) {
+                    Logger.Logit(e.toString());
+                    return null;
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/app/src/main/res/layout/layout_dump1090.xml
+++ b/app/src/main/res/layout/layout_dump1090.xml
@@ -1,0 +1,55 @@
+<!--  
+Copyright (c) 2012, Apps4Av Inc. (apps4av.com) 
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+    *     * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+    *
+    *     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/border_green_small">
+
+    <ImageView
+        android:contentDescription="@string/ADSBWifi"
+        android:id="@+id/main_connectwifi_image"
+        android:layout_margin="10dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@drawable/wireless"
+        />
+    <TextView
+        android:layout_margin="10dp"
+        android:layout_toRightOf="@+id/main_connectwifi_image"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text ="@string/DescDump1090"
+        />
+
+    <com.apps4av.avarehelper.storage.SavedEditText
+        android:id="@+id/main_ip_address"
+        android:layout_width="230dp"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/main_connectwifi_image"
+        android:layout_marginStart="10dp"
+        android:layout_marginLeft="10dp"
+        android:layout_marginTop="10dp"
+        android:layout_marginRight="26dp"
+        android:layout_marginBottom="10dp"
+        android:inputType="text"
+        android:text="192.168.1.1:8080" />
+    <CheckBox
+        android:id="@+id/main_connect1090"
+        android:layout_below="@+id/main_connectwifi_image"
+        android:layout_toRightOf="@+id/main_ip_address"
+        android:layout_width="wrap_content"
+        android:layout_margin="10dp"
+        android:layout_height="wrap_content"
+        android:text="@string/Start"/>
+
+
+</RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,8 +27,10 @@ Redistribution and use in source and binary forms, with or without modification,
     <string name="MSFS">MSFS</string>
     <string name="GPSSIM">GPS Sim</string>
     <string name="USBIN">USB In</string>
+    <string name="DUMP1090">Dump 1090</string>
     <string name="XPlanePort">49002</string>
     <string name="WifiPort">43211</string>
+    <string name="IPAddress">192.168.1.1</string>
     <string name="Exit">Exit</string>
     <string name="Apply">Apply</string>
     <string name="FlyTo">Fly To Destination (if available)</string>
@@ -48,6 +50,7 @@ Redistribution and use in source and binary forms, with or without modification,
     <string name="DescFS">Connect to XPlane, Flightgear on WIFI</string>
     <string name="DescMSFS">Connect to MSFS on WIFI-NMEA</string>
     <string name="DescGPSSim">Simulate GPS</string>
+    <string name="DescDump1090">Connect to Dump1090 via URI</string>
     <string name="DescExt">Connect to GPS/ADSB units on Bluetooth</string>
     <string name="DescExtWifi">Connect to GPS/ADSB units on WiFi (Broadcast on Managed Network)</string>
     <string name="DescFile">Feed NMEA / ADSB data from a binary file</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,7 +30,6 @@ Redistribution and use in source and binary forms, with or without modification,
     <string name="DUMP1090">Dump 1090</string>
     <string name="XPlanePort">49002</string>
     <string name="WifiPort">43211</string>
-    <string name="IPAddress">192.168.1.1</string>
     <string name="Exit">Exit</string>
     <string name="Apply">Apply</string>
     <string name="FlyTo">Fly To Destination (if available)</string>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,4 @@
-#Wed Sep 21 13:58:55 EDT 2016
+#Thu Nov 01 22:07:20 PDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Different from all-in-one Stratux, I built my own ADS-B receiver based on a combination of open source software. I installed gpsd + kplex + dump1090 on my Raspberry Pi 3.

gpsd reads GPS NMEA messages from serial port and kplex broadcasts them. Avare External IO module could receive and parse them in NMEA format on WIFI connection.

ADSB traffic is propagated in a separate path. dump1090 has already included a simple HTTP server and generates JSON traffic feeds at http://[ip address]:[port]/data.json

So I added this Dump1090Connection page, which simply fetches the JSON feeds from dump1090. Data is refreshed every 1 second. dump1090's JSON feeds has very similar structure compared to the traffic JSON feeds sent to Avare.